### PR TITLE
fix(release): simplify release title and notes heading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
             build/dist/*.whl
             build/dist/*.tar.gz
           tag_name: ${{ env.VERSION }}
-          name: GamesTheory ${{ env.VERSION }}
+          name: ${{ env.VERSION }}
           body_path: release-notes.md
           target_commitish: ${{ env.RELEASE_COMMIT_SHA }}
 

--- a/docs/guidelines/release-notes-draft.svg
+++ b/docs/guidelines/release-notes-draft.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="800" viewBox="0 0 960 800" role="img" aria-labelledby="title desc">
   <title id="title">GamesTheory release notes draft</title>
-  <desc id="desc">Mockup of the GamesTheory release notes layout with artifact title, version heading, and grouped pull request sections.</desc>
+  <desc id="desc">Mockup of the GamesTheory release notes layout with a bare version title and grouped pull request sections.</desc>
   <rect width="960" height="800" fill="#f6f8fa"/>
   <rect x="120" y="72" width="720" height="656" rx="8" fill="#ffffff" stroke="#d0d7de"/>
-  <text x="160" y="136" font-family="Arial, Helvetica, sans-serif" font-size="36" font-weight="700" fill="#24292f">GamesTheory 0.3.0</text>
+  <text x="160" y="136" font-family="Arial, Helvetica, sans-serif" font-size="36" font-weight="700" fill="#24292f">0.3.0</text>
   <line x1="160" y1="166" x2="800" y2="166" stroke="#d0d7de"/>
 
   <text x="160" y="218" font-family="Arial, Helvetica, sans-serif" font-size="26" font-weight="700" fill="#24292f">What&apos;s Changed in 0.3.0</text>

--- a/docs/guidelines/release-workflow.md
+++ b/docs/guidelines/release-workflow.md
@@ -52,16 +52,14 @@ Release helper scripts live under `scripts/`:
 The release title is:
 
 ```text
-GamesTheory <version>
+<version>
 ```
 
 Visual draft: `docs/guidelines/release-notes-draft.svg`
 
-The release body starts with the artifact header, then the changes section:
+The release body starts directly with the changes section, avoiding duplication of the version already shown in the release title:
 
 ```markdown
-# GamesTheory <version>
-
 ## What's Changed in <version>
 
 ### 🚀 Features
@@ -89,7 +87,7 @@ Each release-note item links to the pull request. When GitHub provides a `mergeC
 
 The `Authors` section lists unique pull request authors from the same release range.
 
-## Pull Request Title Standard
+## Pull Request And Commit Standard
 
 Pull request titles must use this format because the release workflow categorizes changes from the title of each merged pull request:
 
@@ -125,6 +123,8 @@ Release-note mapping is implemented by `scripts/workflow/generate_release_notes.
 | Any other title | Others |
 
 Prefer the canonical `feat` and `fix` forms for new pull requests. The longer `feature` and `bugfix` aliases remain supported for compatibility with existing titles.
+
+Commit subjects must follow the same `<type>(<optional-scope>): <short summary>` format so repository history and pull request titles remain consistent. Use `feat` for a capability, `fix` for a defect correction, and `chore` for maintenance work that is neither a capability nor a defect correction. Choose the type from the actual purpose of the commit; for example, a correction to release presentation uses `fix(release): ...`. Keep generated release/version commits in the existing `chore(release): ...` form.
 
 ## Verification
 

--- a/docs/guidelines/repository-guide.md
+++ b/docs/guidelines/repository-guide.md
@@ -100,7 +100,7 @@ This guide contains operational repository information for maintainers and agent
 Releases are manual GitHub Actions runs from GitHub's built-in branch selector. Long-lived branches store the next development version in `pyproject.toml` using PEP 440 `.dev0`; leave the optional `version` input empty to release that clean base version, or enter an explicit `X.Y.Z` version to override it. The workflow builds artifacts and tags the clean release-version commit, generates structured release notes from merged pull requests since the previous semver tag, and opens a post-release pull request that moves the selected branch to the next patch `.dev0` version. Release helper scripts and deterministic release tooling tests live in `scripts/workflow/`.
 
 See `docs/guidelines/release-workflow.md` for version selection, release-note grouping, and verification details.
-Pull request titles must follow the standard documented there because their prefixes drive release-note categorization.
+Pull request titles and commit subjects must follow the conventional format documented there. Pull request title prefixes drive release-note categorization, while matching commit subjects keep repository history consistent.
 
 ## Experiment Sandboxes
 

--- a/docs/research/release-automation-tools.md
+++ b/docs/research/release-automation-tools.md
@@ -8,11 +8,12 @@ This note compares ready-made release automation tools that could replace or red
 - Optional explicit `X.Y.Z` version, with empty input defaulting to the next patch.
 - `pyproject.toml` should be updated to the released version through a pull request.
 - GitHub release body should include:
-  - `GamesTheory <version>` header,
+  - a `What's Changed in <version>` heading without repeating the release title,
   - grouped pull request list based on PR title prefixes,
   - Markdown links to each pull request,
   - authors for pull requests in the release range.
 - Existing tag format is bare semver, for example `0.0.2`, without a `v` prefix.
+- GitHub release titles use the same bare semver as the tag.
 
 ## Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "games-theory"
-version = "0.0.4.dev0"
+version = "0.0.3.dev0"
 description = "Q-learning backend for games"
 requires-python = ">=3.9"
 dependencies = [

--- a/scripts/workflow/generate_release_notes.py
+++ b/scripts/workflow/generate_release_notes.py
@@ -165,8 +165,6 @@ def generate_notes(version: str, pull_requests: list[PullRequest]) -> str:
 
     return "\n".join(
         [
-            f"# GamesTheory {version}",
-            "",
             f"## What's Changed in {version}",
             "",
             "### 🚀 Features",

--- a/scripts/workflow/test_release_tools.py
+++ b/scripts/workflow/test_release_tools.py
@@ -341,7 +341,7 @@ def test_generate_release_notes() -> None:
             workdir,
         )
         body = output.read_text(encoding="utf-8")
-        assert "# GamesTheory 1.2.4" in body
+        assert body.startswith("## What's Changed in 1.2.4\n")
         assert "### 🚀 Features" in body
         assert (
             "- feat: add release flow "
@@ -483,6 +483,7 @@ def test_release_workflow_branch_input() -> None:
     assert "ref: ${{ env.RELEASE_BRANCH }}" in content
     assert "ref: ${{ env.RELEASE_COMMIT_SHA }}" in content
     assert "target_commitish: ${{ env.RELEASE_COMMIT_SHA }}" in content
+    assert "name: ${{ env.VERSION }}" in content
     assert '--base "${{ env.RELEASE_BRANCH }}"' in content
     assert '--head "${{ env.RELEASE_UPDATE_BRANCH }}"' in content
 


### PR DESCRIPTION
## What changed

- show only the bare version in the GitHub release list
- start generated release notes directly with `What's Changed in <version>`
- document matching conventional prefixes for pull request titles and commit subjects
- restore `0.0.3.dev0` so the manually removed `0.0.3` release can be published again
- update the release-note draft and deterministic workflow checks

## Why

The previous release title and body both rendered `GamesTheory <version>`, duplicating the heading on the release page. The `0.0.3` release and tag were removed manually, while the development version had already advanced to `0.0.4.dev0`.

## Impact

Release list entries now display only the version. Release descriptions begin with the changes section, and an automatic run with an empty version input selects `0.0.3` again before advancing development to `0.0.4.dev0`.

## Validation

- `python3 scripts/workflow/test_release_tools.py`
- `scripts/verify.sh` (28 tests)
- `git diff --check`
