### PR TITLE
feat(release): publish runtime dependency lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           ref: ${{ env.RELEASE_BRANCH }}
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.9"
 
       - name: Install dependencies
         run: pip install -r games_theory/requirements.txt
@@ -98,18 +98,21 @@ jobs:
         with:
           ref: ${{ env.RELEASE_COMMIT_SHA }}
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.9"
 
       - name: Install build tooling
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build
+          python -m pip install -r scripts/requirements.txt
 
       - name: Build distribution
         run: python -m build
+
+      - name: Build and verify runtime dependency lock
+        run: scripts/workflow/build_dependency_lock.sh "${{ env.VERSION }}"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -150,6 +153,7 @@ jobs:
           files: |
             build/dist/*.whl
             build/dist/*.tar.gz
+            build/dist/*.lock
           tag_name: ${{ env.VERSION }}
           name: ${{ env.VERSION }}
           body_path: release-notes.md

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.9'
 
       - name: Check current directory
         run: ls -la

--- a/docs/guidelines/production-package-guide.md
+++ b/docs/guidelines/production-package-guide.md
@@ -17,6 +17,7 @@ Notes:
 
 - `pyproject.toml` matches the current version, entry points, dependencies, and supported Python version.
 - `flit build` or `pip install .` succeeds without missing package files/resources when release work is in scope.
+- A release dependency lock is generated from the built wheel metadata, contains the complete hashed runtime dependency closure, and installs successfully before the release is published.
 
 ## Runtime And CLI Checklist
 

--- a/docs/guidelines/release-workflow.md
+++ b/docs/guidelines/release-workflow.md
@@ -46,6 +46,34 @@ Release helper scripts live under `scripts/`:
 - `scripts/workflow/generate_release_notes.py`: generates the Markdown release body from git commits.
 - `scripts/workflow/create_version_update_pr.py`: creates the post-release pull request for the next development version.
 - `scripts/workflow/workflow_common.py`: keeps shared version parsing and `pyproject.toml` updates out of the workflow entry points.
+- `scripts/workflow/generate_dependency_lock.py`: reads the built release wheel metadata and generates the versioned, hashed runtime dependency lock.
+- `scripts/workflow/build_dependency_lock.sh`: verifies universal dependency artifacts, installs the lock and wheel in a clean environment, runs `pip check`, and smoke-tests both package CLIs.
+
+## Runtime Dependency Contract
+
+Every GitHub release publishes the project wheel, source distribution, and a lockfile named:
+
+```text
+games-theory-X.Y.Z-requirements.lock
+```
+
+The lockfile is generated from the `Requires-Dist` metadata in the wheel built from the exact release commit. It uses pip requirements syntax and contains the complete transitive runtime dependency closure as exact `==` pins with SHA-256 hashes. Test, coverage, and build-only dependencies are not part of this artifact.
+
+The application consuming the release owns only the selected `games-theory` version. It downloads the wheel and matching lockfile from that GitHub release, then installs them in this order while its build environment has package-index access:
+
+```bash
+python -m pip install \
+  --require-hashes \
+  -r games-theory-X.Y.Z-requirements.lock
+
+python -m pip install \
+  --no-deps \
+  games_theory-X.Y.Z-py3-none-any.whl
+```
+
+The separate `--no-deps` wheel installation is required: it prevents pip from resolving a dependency set different from the library-owned lock. The completed consuming application is responsible for packaging that installed Python environment when its target client must run without Internet access.
+
+Lock generation runs under the lowest supported Python version, currently Python 3.9. Before publication, the workflow requires universal binary artifacts for the resolved dependencies, performs a hash-checked clean installation, checks package consistency, initializes resources, and invokes the game CLI. A version mismatch, missing hash, unsupported environment marker, unavailable universal wheel, failed installation, or failed smoke test stops publication.
 
 ## Release Notes Format
 

--- a/docs/guidelines/repository-guide.md
+++ b/docs/guidelines/repository-guide.md
@@ -98,7 +98,7 @@ This guide contains operational repository information for maintainers and agent
 
 ### Release Workflow
 
-Releases are manual GitHub Actions runs from GitHub's built-in branch selector. Long-lived branches store the next development version in `pyproject.toml` using PEP 440 `.dev0`; leave the optional `version` input empty to release that clean base version, or enter an explicit `X.Y.Z` version to override it. The workflow builds artifacts and tags the clean release-version commit, generates structured release notes from merged pull requests since the previous semver tag, and opens a post-release pull request that moves the selected branch to the next patch `.dev0` version. Release helper scripts and deterministic release tooling tests live in `scripts/workflow/`.
+Releases are manual GitHub Actions runs from GitHub's built-in branch selector. Long-lived branches store the next development version in `pyproject.toml` using PEP 440 `.dev0`; leave the optional `version` input empty to release that clean base version, or enter an explicit `X.Y.Z` version to override it. The workflow builds artifacts and tags the clean release-version commit, generates a versioned, hash-verified runtime dependency lock beside the wheel, generates structured release notes from merged pull requests since the previous semver tag, and opens a post-release pull request that moves the selected branch to the next patch `.dev0` version. Release helper scripts and deterministic release tooling tests live in `scripts/workflow/`.
 
 See `docs/guidelines/release-workflow.md` for version selection, release-note grouping, and verification details.
 Pull request titles and commit subjects must follow the conventional format documented there. Pull request title prefixes drive release-note categorization, while matching commit subjects keep repository history consistent.
@@ -118,7 +118,9 @@ Pull request titles and commit subjects must follow the conventional format docu
 - `scripts/requirements.txt`: complete production-verification environment, including `games_theory/requirements.txt` and package build tooling.
 - `nn/requirements.txt`, `knn/requirements.txt`, `TF/requirements.txt`, `scratch/requirements.txt`: sandbox-specific dependencies derived from each area's imports.
 - `chess_runtime.sh`: helper script for chess-oriented experiments; inspect parameters before running.
-- `scripts/workflow/`: Python helpers used by GitHub Actions release automation and their deterministic checks.
+- `scripts/workflow/`: release automation helpers used by GitHub Actions and their deterministic checks.
+- `scripts/workflow/build_dependency_lock.sh`: generates and verifies the release dependency lock in a clean environment, including universal-wheel availability and CLI smoke checks.
+- `scripts/workflow/generate_dependency_lock.py`: reads runtime requirements from the built wheel metadata and uses `pip-compile` to emit exact transitive pins with SHA-256 hashes.
 - `scripts/verify.sh`: repeatable agent verification: compile production code, run unit, release tooling tests and build package artifacts.
 - `scripts/tictactoe_rebuild.sh`: reinstall package locally and optionally reset tic-tac-toe resources; pass `--reset` as the second argument for non-interactive reset.
 - `scripts/tictactoe_run.sh`: run a tic-tac-toe CLI smoke command against generated resources.

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,4 @@
 -r ../games_theory/requirements.txt
 build
+# Provides pip-compile for resolving the transitive, hashed release lockfile.
+pip-tools==7.5.3

--- a/scripts/workflow/build_dependency_lock.sh
+++ b/scripts/workflow/build_dependency_lock.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <release-version>" >&2
+    exit 2
+fi
+
+version="$1"
+lock_file="dist/games-theory-${version}-requirements.lock"
+verification_environment="build/release-verify"
+verification_config="build/release-verify-config"
+
+python3 scripts/workflow/generate_dependency_lock.py \
+    --version "${version}"
+
+python3 -m pip download \
+    --require-hashes \
+    --only-binary=:all: \
+    --platform any \
+    --python-version 3.9 \
+    --implementation py \
+    --abi none \
+    --dest build/universal-dependencies \
+    -r "${lock_file}"
+
+python3 -m venv "${verification_environment}"
+"${verification_environment}/bin/python" -m pip install \
+    --require-hashes \
+    -r "${lock_file}"
+
+release_wheels=(dist/games_theory-"${version}"-*.whl)
+if [[ ${#release_wheels[@]} -ne 1 || ! -f "${release_wheels[0]}" ]]; then
+    echo "Expected exactly one games-theory ${version} wheel in dist/." >&2
+    exit 1
+fi
+
+"${verification_environment}/bin/python" -m pip install \
+    --no-deps \
+    "${release_wheels[0]}"
+"${verification_environment}/bin/python" -m pip check
+"${verification_environment}/bin/games-theory-init" \
+    "${verification_config}" \
+    --overwrite
+"${verification_environment}/bin/games-theory" \
+    --config "${verification_config}" \
+    0 0 N N N N N N N N N N N N N N N N

--- a/scripts/workflow/generate_dependency_lock.py
+++ b/scripts/workflow/generate_dependency_lock.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Generate a hashed runtime dependency lock from a release wheel."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import tempfile
+import zipfile
+from email.parser import BytesParser
+from email.policy import default
+from pathlib import Path
+
+
+PACKAGE_NAME = "games-theory"
+LOCK_SUFFIX = "requirements.lock"
+HASH_PATTERN = re.compile(r"--hash=sha256:[0-9a-f]{64}\b")
+PIN_PATTERN = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)==([^\s\\]+)")
+
+
+def canonicalize_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def lock_artifact_name(version: str) -> str:
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise ValueError(f"Release version must use X.Y.Z semver. Got: {version}")
+    return f"{PACKAGE_NAME}-{version}-{LOCK_SUFFIX}"
+
+
+def find_release_wheel(dist_dir: Path, version: str) -> Path:
+    normalized_version = version.replace("-", "_")
+    candidates = sorted(dist_dir.glob(f"games_theory-{normalized_version}-*.whl"))
+    if len(candidates) != 1:
+        raise ValueError(
+            f"Expected exactly one games-theory {version} wheel in {dist_dir}; "
+            f"found {len(candidates)}."
+        )
+    return candidates[0]
+
+
+def read_wheel_runtime_requirements(
+    wheel: Path,
+    expected_version: str,
+) -> list[str]:
+    with zipfile.ZipFile(wheel) as archive:
+        metadata_files = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_files) != 1:
+            raise ValueError(
+                f"Expected exactly one METADATA file in {wheel}; "
+                f"found {len(metadata_files)}."
+            )
+        metadata = BytesParser(policy=default).parsebytes(
+            archive.read(metadata_files[0])
+        )
+
+    package_name = metadata.get("Name", "")
+    if canonicalize_name(package_name) != PACKAGE_NAME:
+        raise ValueError(f"Unexpected wheel package name: {package_name or '<missing>'}")
+
+    wheel_version = metadata.get("Version", "")
+    if wheel_version != expected_version:
+        raise ValueError(
+            f"Wheel version {wheel_version or '<missing>'} does not match "
+            f"release version {expected_version}."
+        )
+
+    requirements = sorted(set(metadata.get_all("Requires-Dist", [])))
+    marked = [requirement for requirement in requirements if ";" in requirement]
+    if marked:
+        raise ValueError(
+            "Environment-marked runtime dependencies require an explicit target "
+            f"compatibility design: {', '.join(marked)}"
+        )
+    return requirements
+
+
+def compile_command(source: Path, output: Path) -> list[str]:
+    return [
+        sys.executable,
+        "-m",
+        "piptools",
+        "compile",
+        "--no-config",
+        "--generate-hashes",
+        "--no-header",
+        "--no-annotate",
+        "--no-emit-index-url",
+        "--no-emit-trusted-host",
+        "--strip-extras",
+        "--resolver",
+        "backtracking",
+        "--output-file",
+        str(output),
+        str(source),
+    ]
+
+
+def logical_requirement_blocks(content: str) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    for raw_line in content.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        current.append(stripped.removesuffix("\\").strip())
+        if not stripped.endswith("\\"):
+            blocks.append(" ".join(current))
+            current = []
+    if current:
+        raise ValueError("Lockfile ends with an incomplete line continuation.")
+    return blocks
+
+
+def validate_lock_content(content: str, expected_packages: set[str] | None = None) -> set[str]:
+    blocks = logical_requirement_blocks(content)
+    packages: set[str] = set()
+    for block in blocks:
+        match = PIN_PATTERN.match(block)
+        if match is None:
+            raise ValueError(f"Lock entry is not an exact == pin: {block}")
+        package = canonicalize_name(match.group(1))
+        if package in packages:
+            raise ValueError(f"Duplicate package in lockfile: {package}")
+        if not HASH_PATTERN.search(block):
+            raise ValueError(f"Lock entry has no SHA-256 hash: {package}")
+        if ";" in block or " @ " in block:
+            raise ValueError(f"Target-dependent or direct dependency is unsupported: {block}")
+        packages.add(package)
+
+    if expected_packages is not None and packages != expected_packages:
+        raise ValueError(
+            "Locked package set does not match expected dependency closure: "
+            f"expected {sorted(expected_packages)}, got {sorted(packages)}"
+        )
+    return packages
+
+
+def generate_lock(wheel: Path, version: str, output: Path) -> None:
+    requirements = read_wheel_runtime_requirements(wheel, version)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    if not requirements:
+        output.write_text("", encoding="utf-8")
+        return
+
+    with tempfile.TemporaryDirectory(prefix="games-theory-lock-") as tmp:
+        temp_dir = Path(tmp)
+        source = temp_dir / "runtime-requirements.in"
+        compiled = temp_dir / "runtime-requirements.lock"
+        source.write_text("\n".join(requirements) + "\n", encoding="utf-8")
+        subprocess.run(compile_command(source, compiled), check=True)
+        content = compiled.read_text(encoding="utf-8")
+
+    validate_lock_content(content)
+    output.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate a hashed runtime dependency lock from a release wheel."
+    )
+    parser.add_argument("--version", required=True, help="Clean X.Y.Z release version.")
+    parser.add_argument(
+        "--dist-dir",
+        type=Path,
+        default=Path("dist"),
+        help="Directory containing the built release wheel.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Output lock path. Defaults to the versioned release asset name.",
+    )
+    args = parser.parse_args()
+
+    try:
+        artifact_name = lock_artifact_name(args.version)
+        wheel = find_release_wheel(args.dist_dir, args.version)
+        output = args.output or args.dist_dir / artifact_name
+        generate_lock(wheel, args.version, output)
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    print(f"Generated dependency lock: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workflow/test_release_tools.py
+++ b/scripts/workflow/test_release_tools.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import zipfile
 from pathlib import Path
 
 
@@ -19,6 +20,8 @@ PREPARE_BRANCH = WORKFLOW_SCRIPTS / "prepare_release_branch.py"
 SET_VERSION = WORKFLOW_SCRIPTS / "set_package_version.py"
 NOTES = WORKFLOW_SCRIPTS / "generate_release_notes.py"
 CREATE_PR = WORKFLOW_SCRIPTS / "create_version_update_pr.py"
+DEPENDENCY_LOCK = WORKFLOW_SCRIPTS / "generate_dependency_lock.py"
+BUILD_DEPENDENCY_LOCK = WORKFLOW_SCRIPTS / "build_dependency_lock.sh"
 WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 
 
@@ -33,6 +36,21 @@ def load_release_notes_module():
 
 
 GENERATE_RELEASE_NOTES = load_release_notes_module()
+
+
+def load_dependency_lock_module():
+    spec = importlib.util.spec_from_file_location(
+        "generate_dependency_lock", DEPENDENCY_LOCK
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Cannot load generate_dependency_lock.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+GENERATE_DEPENDENCY_LOCK = load_dependency_lock_module()
 
 
 def run(
@@ -64,6 +82,90 @@ def init_repo(path: Path, version: str = "0.0.0") -> None:
     )
     run(["git", "add", "pyproject.toml"], path)
     run(["git", "commit", "-m", "docs: initial"], path)
+
+
+def create_test_wheel(
+    path: Path,
+    version: str = "1.2.3",
+    requirements: tuple[str, ...] = ("jsbeautifier>=1.14.0",),
+) -> None:
+    metadata = [
+        "Metadata-Version: 2.1",
+        "Name: games-theory",
+        f"Version: {version}",
+    ]
+    metadata.extend(f"Requires-Dist: {requirement}" for requirement in requirements)
+    metadata.append("")
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            f"games_theory-{version}.dist-info/METADATA",
+            "\n".join(metadata),
+        )
+
+
+def test_dependency_lock_helpers() -> None:
+    digest = "a" * 64
+    valid_lock = (
+        f"editorconfig==0.17.1 \\\n    --hash=sha256:{digest}\n"
+        f"jsbeautifier==1.15.4 \\\n    --hash=sha256:{digest}\n"
+        f"six==1.17.0 \\\n    --hash=sha256:{digest}\n"
+    )
+    expected = {"editorconfig", "jsbeautifier", "six"}
+    assert GENERATE_DEPENDENCY_LOCK.validate_lock_content(valid_lock) == expected
+    GENERATE_DEPENDENCY_LOCK.validate_lock_content(valid_lock, expected)
+    assert (
+        GENERATE_DEPENDENCY_LOCK.lock_artifact_name("1.2.3")
+        == "games-theory-1.2.3-requirements.lock"
+    )
+
+    command = GENERATE_DEPENDENCY_LOCK.compile_command(
+        Path("requirements.in"), Path("requirements.lock")
+    )
+    assert "--generate-hashes" in command
+    assert "--no-config" in command
+    assert "--no-emit-index-url" in command
+
+    for invalid_lock in (
+        "jsbeautifier>=1.14.0\n",
+        "jsbeautifier==1.15.4\n",
+        f"jsbeautifier==1.15.4; python_version > '3.9' --hash=sha256:{digest}\n",
+    ):
+        try:
+            GENERATE_DEPENDENCY_LOCK.validate_lock_content(invalid_lock)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"Invalid lock was accepted: {invalid_lock}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        directory = Path(tmp)
+        wheel = directory / "games_theory-1.2.3-py3-none-any.whl"
+        create_test_wheel(wheel)
+        assert GENERATE_DEPENDENCY_LOCK.find_release_wheel(directory, "1.2.3") == wheel
+        assert GENERATE_DEPENDENCY_LOCK.read_wheel_runtime_requirements(
+            wheel, "1.2.3"
+        ) == ["jsbeautifier>=1.14.0"]
+
+        try:
+            GENERATE_DEPENDENCY_LOCK.read_wheel_runtime_requirements(wheel, "1.2.4")
+        except ValueError as error:
+            assert "does not match" in str(error)
+        else:
+            raise AssertionError("Wheel version mismatch was accepted")
+
+        marked_wheel = directory / "marked.whl"
+        create_test_wheel(
+            marked_wheel,
+            requirements=("jsbeautifier>=1.14.0; python_version >= '3.9'",),
+        )
+        try:
+            GENERATE_DEPENDENCY_LOCK.read_wheel_runtime_requirements(
+                marked_wheel, "1.2.3"
+            )
+        except ValueError as error:
+            assert "Environment-marked" in str(error)
+        else:
+            raise AssertionError("Environment marker was accepted")
 
 
 def test_prepare_release() -> None:
@@ -484,11 +586,22 @@ def test_release_workflow_branch_input() -> None:
     assert "ref: ${{ env.RELEASE_COMMIT_SHA }}" in content
     assert "target_commitish: ${{ env.RELEASE_COMMIT_SHA }}" in content
     assert "name: ${{ env.VERSION }}" in content
+    assert "python-version: \"3.9\"" in content
+    assert 'build_dependency_lock.sh "${{ env.VERSION }}"' in content
+    assert "build/dist/*.lock" in content
     assert '--base "${{ env.RELEASE_BRANCH }}"' in content
     assert '--head "${{ env.RELEASE_UPDATE_BRANCH }}"' in content
 
+    lock_script = BUILD_DEPENDENCY_LOCK.read_text(encoding="utf-8")
+    assert "set -euo pipefail" in lock_script
+    assert "generate_dependency_lock.py" in lock_script
+    assert "--require-hashes" in lock_script
+    assert "--no-deps" in lock_script
+    assert "--platform any" in lock_script
+
 
 def main() -> int:
+    test_dependency_lock_helpers()
     test_prepare_release()
     test_prepare_release_uses_branch_local_previous_tag()
     test_prepare_release_rejects_branch_local_downgrade()


### PR DESCRIPTION
## What changed

- publish a versioned `games-theory-X.Y.Z-requirements.lock` beside each release wheel and source distribution
- derive the complete transitive runtime dependency set from the built wheel metadata
- pin dependencies with SHA-256 hashes using `pip-compile`
- verify universal wheels, a clean hash-enforced installation, `pip check`, resource initialization, and CLI execution before publication
- keep release workflow orchestration in repeatable scripts under `scripts/workflow/`
- document the downstream contract: install the lock first, then the wheel with `--no-deps`

## Why

GamesTheoryAI should own only `GAME_THEORY_VERSION`. The Python library release now owns the compatible dependency contract, while the consuming application can download dependencies during its build and ship a prepared environment to clients that run without Internet access.

## Impact

Existing wheel and source-distribution publication remains unchanged. Releases additionally contain the matching hashed lockfile. A stale, incomplete, incompatible, or non-portable dependency set stops the release before publication.

## Validation

- `python3 scripts/workflow/test_release_tools.py`
- `scripts/verify.sh`
- 28 production tests
- package wheel and sdist build
- repeated lock generation produced identical output
- universal-wheel download for the Python 3.9 support floor
- clean `--require-hashes` dependency installation
- project wheel installation with `--no-deps`
- `pip check`, `games-theory-init`, and `games-theory` smoke tests