### PR TITLE
ci: reuse test workflow in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
     secrets: inherit
 
   prepare:
-    needs: test
     runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,34 +17,11 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_BRANCH }}
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install dependencies
-        run: pip install -r games_theory/requirements.txt
-
-      - name: Run unittests
-        run: coverage run -m unittest discover games_theory
-
-      - name: Create coverage report
-        run: coverage xml
-
-      - name: Upload coverage report
-        if: success()
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l Python -r coverage.xml
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   prepare:
+    needs: test
     runs-on: ubuntu-latest
     outputs:
       VERSION: ${{ steps.version.outputs.VERSION }}
@@ -98,10 +75,10 @@ jobs:
         with:
           ref: ${{ env.RELEASE_COMMIT_SHA }}
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.9"
 
       - name: Install build tooling
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: test
 
 on:
+  workflow_call:
   pull_request:
   push:
     branches:
@@ -13,10 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.9'
 
       - name: Check current directory
         run: ls -la


### PR DESCRIPTION
## What changed

- expose `.github/workflows/test.yml` as a reusable workflow through `workflow_call`
- call the shared test workflow as the first release job
- gate release preparation on successful tests
- run tests and package builds with Python 3.9
- remove duplicated test steps from `release.yml`

## Why

The release workflow duplicated the repository test workflow and used Python 3.11, while the supported library compatibility baseline is Python 3.9. Reusing one workflow keeps test behavior consistent and makes tests an explicit release gate.

## Impact

Manual releases now stop before preparation when the shared test workflow fails. CI and release artifact builds use Python 3.9.

## Validation

- `git diff --check`
- YAML parsing for both workflow files
- `python3 -m unittest discover games_theory` — 28 tests passed locally

Python 3.9 was not installed locally, so the GitHub Actions run provides the final Python 3.9 validation.