### PR TITLE
docs: separate routing from durable documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,44 @@ Use this file first to identify the required repository context. Read every docu
 - Use the smallest applicable set of documents from the routing table below; when a task crosses areas, combine their required context.
 - Preserve user changes already present in the worktree and keep code, documentation, plans, and scripts in English.
 
+## Repository Map
+
+| Path | Responsibility |
+| --- | --- |
+| `README.md` | Short human-facing project purpose, maturity, documentation links, and quick start. |
+| `pyproject.toml` | Package metadata, runtime dependencies, Python compatibility, CLI entry points, and build configuration. |
+| `games_theory/process.py` | CLI validation, configuration loading, predictor orchestration, and JSON result output. |
+| `games_theory/resources/**` | Packaged defaults, resource initialization, copying, loading, and saving. |
+| `games_theory/src/config_repository.py` | Typed configuration loading at the process boundary. |
+| `games_theory/src/domain_types.py` | Shared state, points, pending-move, configuration, coordinate, and Q-table contracts. |
+| `games_theory/src/default_predictor.py` | Evaluation, action selection, and persistence orchestration. |
+| `games_theory/src/predictor/**` | State encoding, reward policy, scoring, action selection, and state/Q-table repositories. |
+| `games_theory/src/generator.py` | Legal bot-move generation from canonical states. |
+| `games_theory/src/move_coordinate_deriver.py` | Selected-transition validation and public coordinate derivation. |
+| `games_theory/test/**` | Production package unit, resource, predictor, and CLI tests. |
+| `games_theory/README.md`, `games_theory/changelog` | Package-local usage and historical package changes. |
+| `nn/**` | Perceptron and feed-forward neural-network experiments. |
+| `knn/**` | k-NN experiments, dataset helpers, and charting. |
+| `TF/**` | TensorFlow and GPU prototypes. |
+| `scratch/**` | Disposable algorithm checks and prototypes. |
+| `data/**` | Local runtime configuration, pending-move state, and learned Q-table; treat as user data and do not modify unless explicitly requested. |
+| `docs/domain/games-theory-domain.md` | Game rules, Q-learning language, state semantics, and persistence meaning. |
+| `docs/domain/ml-sandbox-domain.md` | Experiment boundaries, terminology, and sandbox expectations. |
+| `docs/guidelines/repository-guide.md` | Environment, commands, module operation, testing, tooling, and release overview. |
+| `docs/guidelines/engineering-guide.md` | Application design, coding, testing, and review rules. |
+| `docs/guidelines/production-package-guide.md` | Production package, CLI, persistence, packaging, and verification checklist. |
+| `docs/guidelines/project-lifecycle.md` | Proposal, approval, implementation, and closeout process. |
+| `docs/guidelines/release-workflow.md` | Versioning, release notes, and publication process. |
+| `docs/architecture/**` | Runtime and integration diagrams. |
+| `docs/projects/**` | Temporary plans for active non-trivial work. |
+| `docs/research/**` | Durable investigations and evaluated tooling alternatives. |
+| `scripts/verify.sh`, `scripts/requirements.txt` | Complete local verification entry point and its dependencies. |
+| `scripts/tictactoe_*.sh` | Repeatable local package rebuild and CLI smoke workflows. |
+| `scripts/workflow/**` | Release preparation, dependency locking, release-note generation, version PR creation, and deterministic tooling tests. |
+| `.github/workflows/test.yml` | Repository test workflow. |
+| `.github/workflows/release.yml` | Manual package build and GitHub release workflow. |
+| `dist/**` | Generated package artifacts; do not review or commit. |
+
 ## Task Routing
 
 | Task or touched area                                                 | Read before work                                                                                                                      |
@@ -17,11 +55,17 @@ Use this file first to identify the required repository context. Read every docu
 | `games_theory/**`                                                    | `docs/domain/games-theory-domain.md`, `docs/guidelines/production-package-guide.md`, and relevant `docs/architecture/**` diagrams     |
 | Game rules, state semantics, Q-learning meaning, or domain naming    | `docs/domain/games-theory-domain.md`                                                                                                  |
 | Persistence, resource formats, service boundaries, or predictor flow | `docs/domain/games-theory-domain.md`, `docs/guidelines/production-package-guide.md`, and `docs/architecture/qlearning_algorithm.puml` |
-| CLI orchestration or integration flow                                | Relevant `docs/architecture/**` diagrams and `docs/guidelines/production-package-guide.md`                                            |
-| `nn/`, `knn/`, `TF/`, `scratch/`, or `data/`                         | `docs/domain/ml-sandbox-domain.md` and the experiment guidance in `docs/guidelines/repository-guide.md`                               |
-| Setup, tests, packaging, repository scripts, or release work         | Relevant sections of `docs/guidelines/repository-guide.md`; for releases also read `docs/guidelines/release-workflow.md`              |
+| CLI orchestration or integration flow                                | `docs/guidelines/repository-guide.md`, relevant `docs/architecture/**` diagrams, and `docs/guidelines/production-package-guide.md`     |
+| `nn/`, `knn/`, `TF/`, or `scratch/`                                  | `docs/domain/ml-sandbox-domain.md` and the experiment guidance in `docs/guidelines/repository-guide.md`                               |
+| Root `data/**`                                                       | `docs/domain/games-theory-domain.md`, `docs/guidelines/production-package-guide.md`, and `docs/architecture/qlearning_algorithm.puml` |
+| Setup, tests, packaging, or repository scripts                       | Relevant sections of `docs/guidelines/repository-guide.md`; add the guide for the touched code area                                  |
+| Release workflow, versioning, release notes, or dependency locks     | `docs/guidelines/repository-guide.md`, `docs/guidelines/release-workflow.md`, and relevant `docs/research/**` notes                    |
 | Tool selection or previously researched automation                   | Relevant `docs/research/**` notes                                                                                                     |
-| Documentation, review, or refactoring                                | Relevant standards in `docs/guidelines/engineering-guide.md` plus the guide for the touched area                                      |
+| Root `README.md`                                                     | Relevant domain documents plus user-facing setup and interfaces in `docs/guidelines/repository-guide.md`                              |
+| Domain or terminology documentation                                  | Relevant `docs/domain/**` document and implemented behavior                                                                          |
+| Engineering standards, review, or refactoring                        | `docs/guidelines/engineering-guide.md` plus the domain and production guide for the touched area                                      |
+| Operational documentation                                            | `docs/guidelines/repository-guide.md` plus the implementation and scripts being documented                                            |
+| Architecture documentation                                          | Relevant `docs/architecture/**`, domain guide, and implemented runtime flow                                                           |
 | Non-trivial project planning and delivery                            | `docs/guidelines/project-lifecycle.md`                                                                                                |
 
 ## Repository-Specific Instructions

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 # NeuralNetworks
 
-NeuralNetworks is a machine-learning playground and a growing game-theory package. The repository combines exploratory ML experiments with a production-oriented Python library for Q-learning in turn-based games.
+NeuralNetworks is a Python project for exploring machine-learning algorithms and developing a reusable Q-learning backend for turn-based games. It combines lightweight neural-network, k-NN, and TensorFlow experiments with the production-oriented `games-theory` package.
 
-The main practical target today is a reusable Q-learning backend for games like tic-tac-toe. The longer-term direction is to keep extending the same ideas toward richer turn-based domains, including chess experiments.
-
-## What Is Inside
-
-- `games_theory/`: installable Python package with CLI tools, resource management, and a Q-learning predictor loop.
-- `nn/`, `knn/`, `TF/`, `scratch/`: experimental sandboxes for neural networks, k-NN, TensorFlow checks, and quick prototypes.
+The current practical use case is a CLI-driven predictor for games such as tic-tac-toe. The experimental areas remain intentionally small and support learning, comparison, and prototyping rather than production deployment.
 
 ## Documentation
 
 - Repository guide: [`docs/guidelines/repository-guide.md`](docs/guidelines/repository-guide.md)
+- Game-theory domain: [`docs/domain/games-theory-domain.md`](docs/domain/games-theory-domain.md)
+- Machine-learning sandbox domain: [`docs/domain/ml-sandbox-domain.md`](docs/domain/ml-sandbox-domain.md)
 
 ## Quick Start
 
@@ -21,4 +18,4 @@ python -m venv .venv && source .venv/bin/activate
 ./scripts/tictactoe_run.sh ./demo
 ```
 
-For CLI examples and detailed workflows, use the repository guide.
+The repository guide contains setup, CLI, testing, packaging, and release details.

--- a/docs/architecture/qlearning_algorithm.puml
+++ b/docs/architecture/qlearning_algorithm.puml
@@ -1,5 +1,5 @@
 @startuml
-' High-level Q-learning loop (as implemented by Process + DefaultPredictor)
+' One games-theory CLI invocation
 
 skinparam activity {
     BackgroundColor #fdfdfd
@@ -7,27 +7,42 @@ skinparam activity {
 }
 
 start
-:Initialize environment\n- load config (board-size, learning flag)\n- ensure qtable/state files exist;
-:Observe current board state S;
+:Parse CLI input and load configuration;
+:Validate board length and normalize\nX/O/N cells into canonical state S;
+:Load qtable.json and state.json;
 
-while (game continues?) is (yes)
-    if (previous move exists?) then (yes)
-    :Compute reward R\n = advantage(current points) - advantage(previous points);
-    :Update Q(S_prev, A_prev)\nQ ← Q + α*(R + γ*max_a' Q(S, a') - Q)\nwhere α=learning rate, γ=discount;
+if (learning enabled?) then (yes)
+    if (pending last_move exists?) then (yes)
+        :Compute reward R\n= current advantage - previous advantage;
+        :Update Q(S_prev, A_prev)\nQ ← Q + α*(R + γ*max_a' Q(S, a') - Q);
+        :Persist Q-table and clear last_move;
     else (no)
-        :Skip update (no prior transition);
+        :Skip the deferred update;
     endif
 
-    :Enumerate legal actions A for S\n(using Generator → neighbour states);
-    :Select next action A*\n- weight actions by stored Q(S, a)\n- fallback to uniform random if all equal;
-    :Persist chosen transition\n(store {S, A*, points} as last_move);
-    :Derive zero-based {x, y}\nfrom the changed row-major cell;
-    :Emit move coordinate as JSON\n(or null when no action exists);
-    :Apply action in environment → obtain new board + updated points;
-    :Set S_prev ← S, S ← next state;
-endwhile (no)
+    :Ensure legal neighbour states for S\nexist in the Q-table;
+    :Select A* using stored Q-values\nand weighted randomness;
 
-:Persist final snapshot (qtable + state);
+    if (legal action selected?) then (yes)
+        :Persist {S, A*, points, advantage}\nas last_move;
+    else (no)
+        :Persist last_move = null;
+    endif
+    :Persist updated Q-table;
+else (no)
+    :Read known neighbours from the Q-table\nor generate legal neighbours in memory;
+    :Select A* without modifying state or Q-table;
+endif
+
+if (legal action selected?) then (yes)
+    :Validate the state transition;
+    :Derive zero-based {x, y}\nfrom the changed row-major cell;
+    :Emit {x, y} as JSON;
+else (no)
+    :Emit null as JSON;
+endif
+
+:Write diagnostics to standard error;
 stop
 
 @enduml

--- a/docs/domain/games-theory-domain.md
+++ b/docs/domain/games-theory-domain.md
@@ -1,14 +1,17 @@
 # Game Theory Domain
 
-This file describes the production game-theory domain from a DDD perspective. Use it before changing Q-learning behaviour, naming, persistence contracts, or public workflows in `games_theory/**`.
+This document defines the durable language, boundaries, and invariants of the turn-based Q-learning domain.
 
 ## Bounded Contexts
 
-| Context | Code paths | Responsibility |
-| --- | --- | --- |
-| Game Theory Runtime | `games_theory/**` | Runs the turn-based Q-learning backend, persists learning state, and exposes CLI entry points. |
+| Context | Responsibility |
+| --- | --- |
+| Game Interface | Accepts the current board and score, then returns the selected move as a public coordinate. |
+| State Normalization | Converts external board symbols into a bot-relative canonical representation. |
+| Learning | Evaluates the previous transition, maintains Q-values, and selects the next legal action. |
+| Persistence | Stores configuration, a pending previous move, and learned transition quality across invocations. |
 
-## Game Theory Ubiquitous Language
+## Ubiquitous Language
 
 - **Board state**: flattened board passed by the caller in row-major order using external symbols (`X`, `O`, `N`).
 - **Canonical state**: internal bot-relative state where `-1 = bot`, `1 = opponent`, and `0 = empty`.
@@ -23,5 +26,6 @@ This file describes the production game-theory domain from a DDD perspective. Us
 - `X` always starts in the external game, but the bot may be either `X` or `O`; runtime logic must use `ai-char` to normalize state.
 - Q-learning data must stay independent from the external bot symbol whenever possible, so changing `ai-char` does not require relearning from scratch.
 - `state.json` stores only pending transition data; `qtable.json` stores learned transition quality.
-- Resource format changes are production changes and require tests plus documentation updates.
+- Configuration, pending-move state, and learned transition quality have separate lifecycles and remain separate persisted concepts.
+- Persisted learning data must remain independent from incidental process state.
 - The CLI writes exactly one machine-readable JSON result to standard output: a move coordinate object or `null` when no legal move exists. Human-readable diagnostics belong on standard error.

--- a/docs/domain/ml-sandbox-domain.md
+++ b/docs/domain/ml-sandbox-domain.md
@@ -1,27 +1,27 @@
 # Machine Learning Sandbox Domain
 
-This file describes the exploratory machine-learning sandbox domain. Use it before changing experiment structure, datasets, prototype scripts, or research workflows outside the production `games_theory/**` package.
+This document defines the purpose, language, and boundaries of the exploratory machine-learning sandboxes.
 
 ## Bounded Context
 
-| Context | Code paths | Responsibility |
-| --- | --- | --- |
-| Neural Network Experiments | `nn/**`, `nn/nn_main.py` | Prototype perceptron and feed-forward neural-network behaviour. |
-| k-NN Experiments | `knn/**`, `knn_main.py` | Explore distance metrics, neighbor voting, weighting, and charting. |
-| TensorFlow Prototypes | `TF/**` | Validate TensorFlow/GPU setup and prototype network definitions. |
-| Scratch Space | `scratch/**`, `data/**` | Hold quick checks, sample data, and disposable algorithm explorations. |
+| Context | Responsibility |
+| --- | --- |
+| Neural Network Experiments | Prototype perceptron and feed-forward neural-network behaviour. |
+| k-NN Experiments | Explore distance metrics, neighbour voting, weighting, and charting. |
+| TensorFlow Prototypes | Validate TensorFlow/GPU setup and prototype network definitions. |
+| Scratch Space | Hold quick checks, sample data, and disposable algorithm explorations. |
 
 ## Ubiquitous Language
 
 - **Experiment**: localized code used to test an algorithmic idea without production packaging guarantees.
 - **Prototype**: implementation intended for learning or validation before any production extraction.
-- **Dataset**: local input data used by experiments; changes should be documented when they affect reproducibility.
+- **Dataset**: input data used by an experiment and interpreted under that experiment's assumptions.
 - **Smoke check**: lightweight command that proves a prototype still runs for its expected input shape.
 
 ## Domain Rules
 
-- Optimize sandbox changes for correctness, clarity, and research velocity.
+- Sandboxes optimize for correctness, clarity, and research velocity rather than packaging guarantees.
 - Keep experiment-specific abstractions local until there is a repeated, concrete need to share them.
 - Do not impose production package structure on experiments unless it fixes a real maintenance or correctness problem.
-- Document non-obvious experiment assumptions near the experiment or in this domain file.
-- If sandbox work graduates into production behaviour, move the durable domain language into the relevant production domain docs.
+- Reproducible results identify the relevant dataset, dependency versions, parameters, and sources of randomness.
+- Prototype behavior is not a production contract until it is deliberately adopted by a production domain.

--- a/docs/guidelines/engineering-guide.md
+++ b/docs/guidelines/engineering-guide.md
@@ -1,17 +1,43 @@
 # Engineering Guide
 
-Use these guidelines when designing or reviewing changes. `AGENTS.md` decides which guideline applies to a task; this file captures project-level rules that should not be scattered through implementation comments.
+This guide defines how NeuralNetworks code should be designed, implemented, and tested.
 
-## Design Principles
+## Application Structure
 
-- Keep production code in `games_theory/**` explicit about persistence, CLI contracts, and resource ownership.
-- Put lifecycle and mode decisions in the upper-level orchestrator; lower-level services should expose explicit operations instead of boolean switches that change persistence or side effects.
-- Prefer small composed services over broad classes when a component owns a distinct persistence or policy concern.
-- Keep experimental directories lightweight; do not introduce production-grade structure there unless it fixes a concrete problem.
-- Update documentation in the same change when behaviour, public CLI usage, persistence format, or architecture flow changes.
-- Plan non-trivial changes in `docs/projects/**` before implementation, finish with a test phase, then delete completed project plans after durable docs/TODOs are updated.
-- Store repeatable process automation and verification commands under `scripts/**`.
-- Write documentation, plans, scripts, and code in English.
+- Keep the CLI and other entry points responsible for input parsing, dependency construction, and top-level workflow selection.
+- Keep game rules, state encoding, learning policy, and move selection independent of CLI parsing and filesystem formats.
+- Put lifecycle and mode decisions in the top-level orchestrator; lower-level services should expose explicit operations instead of boolean switches that alter persistence or side effects.
+- Isolate configuration, state, and Q-table persistence behind repositories with clear ownership of each resource.
+- Inject configuration, randomness, and persistence collaborators when business logic needs them; do not construct external dependencies deep inside domain logic.
+- Prefer small components with one reason to change over broad classes that combine policy, orchestration, and persistence.
+- Keep experimental code lightweight and local to the experiment until a repeated need justifies extraction.
+
+## Domain Types And State
+
+- Represent board state, points, pending moves, configuration, Q-table entries, and public move coordinates with explicit types.
+- Normalize external `X`, `O`, and `N` symbols at the application boundary; learning logic should operate on bot-relative canonical state.
+- Keep row-major indexing and zero-based public coordinates explicit at conversion boundaries.
+- Validate state transitions before deriving a move or applying a learning update.
+- Keep persistent resource schemas independent from incidental in-memory implementation details.
+- Treat absent state, malformed state, and a valid empty state as different conditions.
+
+## Error Handling And Public Interfaces
+
+- Validate CLI arguments and configuration before starting prediction or mutating persisted state.
+- Return contextual errors from parsing, validation, persistence, state encoding, and prediction paths.
+- Do not silently recover from malformed configuration or persisted learning data when doing so could overwrite user state.
+- Write only the documented machine-readable result to standard output; send diagnostics to standard error.
+- Keep public CLI behavior and importable APIs backward-compatible unless an intentional contract change includes migration and regression coverage.
+- Make initialization, overwrite, reset, read-only, and learning operations explicit rather than inferring them from ambiguous flags.
+
+## Persistence And Side Effects
+
+- Use the owning repository or resource service for reads and writes instead of accessing JSON files from orchestration or policy code.
+- Keep configuration, pending-move state, and learned Q-values in separate resources because they have different lifecycles.
+- Persist related state changes in a deliberate order and avoid leaving partially updated resources after a failure.
+- Do not overwrite user resources outside an explicit initialization or reset operation.
+- Keep reusable package code independent of the repository checkout and current working directory.
+- Make randomness an explicit policy dependency when deterministic behavior is needed for tests.
 
 ## Anti-patterns
 
@@ -21,29 +47,20 @@ Use these guidelines when designing or reviewing changes. `AGENTS.md` decides wh
 - Do not silently overwrite user resources outside explicit init/reset workflows.
 - Do not hide write/read-only mode changes behind generic boolean flags inside lower-level services; split the operation and let the orchestrator choose.
 
-## Documentation Standard
+## Testing
 
-- Root `README.md` is a short visitor overview: motivation, purpose, and links to concrete docs.
-- Root `AGENTS.md` is the agent orchestrator: it contains task-to-document routing and repository-specific agent instructions, while detailed standards and checklists live under `docs/**`.
-- `docs/domain/**` contains domain language, rules, and bounded-context notes split by concrete domain.
-- `docs/guidelines/**` contains engineering rules, review expectations, documentation standards, repository guide, and anti-patterns.
-- `docs/architecture/**` contains diagrams and integration/control-flow descriptions.
-- `docs/projects/**` contains temporary active project plans; completed plans are deleted after tests.
-- `docs/guidelines/repository-guide.md` contains repository map, setup, workflows, testing, tooling, and release notes.
-- `scripts/**` contains repeatable automation and verification entry points.
+- Unit-test state normalization, neighbour generation, Q-value updates, reward calculation, transition validation, and coordinate derivation.
+- Cover malformed inputs, incompatible resource data, missing files, empty legal-move sets, and persistence failures.
+- Use temporary resources and injected collaborators instead of modifying packaged defaults or user data in tests.
+- Keep tests deterministic by controlling randomness and filesystem state.
+- Add a regression test for every corrected prediction, persistence, or public-interface bug.
+- Test experiments at the level needed to protect their algorithmic result without imposing production structure that provides no concrete benefit.
 
-When changing documentation:
-
-- Keep links current after moves or renames.
-- Put durable information in the most focused domain, guideline, architecture, or research document instead of a temporary plan or catch-all file.
-- Keep active plans under `docs/projects/**` and remove them only through the project lifecycle closeout.
-- Write documentation and plans in English.
-
-## Review Standard
+## Code Review Standard
 
 - Focus on correctness, behavioural regressions, user-data loss, persistence safety, public contract changes, and missing tests.
 - Make findings actionable by explaining the impact and pointing to specific files and lines.
 - Avoid cosmetic findings unless they hide a functional problem or make domain or persistence semantics unclear.
-- For production changes, use `docs/guidelines/production-package-guide.md` as the detailed checklist.
-- For experimental code, prioritize algorithmic correctness and clarity; require production-grade structure only when a concrete risk justifies it.
-- For documentation changes, verify ownership, consistency, and links rather than duplicating the same guidance across entry points.
+- Verify that abstractions reduce coupling without hiding game rules, learning semantics, or side effects.
+- Require tests for changed parsing, state transitions, learning policy, persistence, and failure handling.
+- For experimental code, prioritize algorithmic correctness and clarity; require additional structure only when a concrete risk justifies it.

--- a/docs/guidelines/production-package-guide.md
+++ b/docs/guidelines/production-package-guide.md
@@ -1,21 +1,17 @@
 # Production Package Guide
 
-Use these checks when touching `games_theory/**`. They replace the old module-local agent briefing; root `AGENTS.md` remains the only agent briefing entry point.
+This guide defines the production quality standard for the `games-theory` package.
 
 ## Scope And Priorities
 
-| Area               | Paths                                               | Expectations                                                                                                                                                                             |
-|--------------------|-----------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Production package | `games_theory/**`                                   | Maintain installability via Flit, stable public APIs, CLI behaviour (`games-theory`, `games-theory-init`), resource/config compatibility, persistence correctness, and regression tests. |
-| Shared resources   | `games_theory/resources/**`, `games_theory/test/**` | Treat as part of the production surface; ensure packaged defaults are valid and tests cover new functionality.                                                                           |
-
-Notes:
-- The package may be published independently; avoid repo-relative assumptions in package runtime code.
-- Resource formats must remain backward-compatible unless migration scripts and tests are provided.
+- The installable package, CLI entry points, packaged defaults, persistence formats, and public Python interfaces form one production surface.
+- The package may be published independently and must not depend on the repository checkout at runtime.
+- Public interfaces and resource formats remain backward-compatible unless an explicit migration path and regression coverage are provided.
+- Packaged defaults must be valid, internally consistent, and safe to copy into a new environment.
 
 ## Packaging And Release Checklist
 
-- `pyproject.toml` matches the current version, entry points, dependencies, and supported Python version.
+- Package metadata matches the current version, entry points, runtime dependencies, and supported Python version.
 - `flit build` or `pip install .` succeeds without missing package files/resources when release work is in scope.
 - A release dependency lock is generated from the built wheel metadata, contains the complete hashed runtime dependency closure, and installs successfully before the release is published.
 
@@ -27,11 +23,12 @@ Notes:
 
 ## Predictor And Persistence Checklist
 
-- Changes to `DefaultPredictor`, `Generator`, repositories, or predictor policies preserve state compatibility and include tests.
-- `qtable.json` and `state.json` changes are documented in `docs/domain/games-theory-domain.md` and covered by tests.
-- Architecture docs are updated when predictor/control flow changes materially.
+- Predictor, generator, repository, and policy changes preserve state compatibility and include regression coverage.
+- `qtable.json` and `state.json` changes preserve their domain meaning or provide an explicit migration.
+- Predictor and persistence failures must not leave user resources silently corrupted or partially reset.
 
 ## Test Checklist
 
-- Unit tests under `games_theory/test/**` are updated for production logic changes.
-- CLI or integration smoke tests are scripted under `scripts/**` when they become repeatable verification steps.
+- Unit tests cover changed production logic, public contracts, and failure handling.
+- CLI and integration smoke checks cover installability, packaged resources, initialization, and prediction output.
+- The complete verification workflow must build the package from its declared metadata rather than relying only on editable imports.

--- a/docs/guidelines/project-lifecycle.md
+++ b/docs/guidelines/project-lifecycle.md
@@ -1,11 +1,11 @@
-# Project lifecycle
+# Project Lifecycle
 
 Use this workflow for non-trivial changes, including changes that require
 architectural or product decisions before implementation.
 
-## 1. Project proposal
+## 1. Project Proposal
 
-Create one Markdown file under `docs/projects`. The proposal must describe:
+Create one Markdown project proposal. The proposal must describe:
 
 - the problem and intended outcome;
 - confirmed decisions and assumptions;
@@ -19,7 +19,7 @@ Create one Markdown file under `docs/projects`. The proposal must describe:
 The proposal has status `PROPOSED`. No production implementation starts during
 this stage.
 
-## 2. Proposal review
+## 2. Proposal Review
 
 The repository owner reviews the project file. Discussion and corrections are
 applied to the proposal itself so the accepted design is explicit.
@@ -44,7 +44,7 @@ summary containing:
 
 Set the project status to `IMPLEMENTED`.
 
-## 4. Implementation review
+## 4. Implementation Review
 
 The repository owner reviews the implementation and its verification results.
 Requested changes return to the implementation stage.
@@ -54,18 +54,16 @@ owner explicitly accepts the implementation.
 
 Set the project status to `APPROVED FOR DOCUMENTATION`.
 
-## 5. Documentation and cleanup
+## 5. Documentation And Cleanup
 
 After implementation acceptance:
 
-1. update the relevant permanent documents under `docs/domain`,
-   `docs/guidelines` and `docs/architecture`;
-2. update `README.md` only if user-facing product or quick-start information
-   changed;
-3. update `AGENTS.md` if repository routing changed;
-4. remove the completed project file from `docs/projects`;
-5. run link, formatting, and relevant build checks;
-6. present the final diff for commit or publication approval.
+1. Update permanent documentation to match the accepted behavior and decisions.
+2. Update visitor-facing documentation when purpose, maturity, or usage changed.
+3. Preserve reusable investigation outcomes as permanent research notes.
+4. Remove the completed project proposal.
+5. Run link, formatting, and relevant build checks.
+6. Present the final change set for commit or publication approval.
 
 The Git history preserves the reviewed plan while the working tree retains only
 current documentation.
@@ -101,5 +99,5 @@ Mark steps as `[pending]`, `[in-progress]`, or `[done]` as work progresses so in
 - `<command>`
 
 ## Result
-- <Temporary summary used during active work only. Delete this file after user acceptance, cleanup, and durable documentation/TODOs are updated.>
+- <Temporary summary. Delete this file after owner acceptance, cleanup, and permanent documentation updates.>
 ```

--- a/docs/guidelines/repository-guide.md
+++ b/docs/guidelines/repository-guide.md
@@ -1,33 +1,6 @@
 # Repository Guide
 
-This guide contains operational repository information for maintainers and agents. The root `README.md` is intentionally short and visitor-oriented; use this file for setup, module maps, workflows, testing, and release details.
-
-## Quick Links
-
-- Agent routing and review policy: `AGENTS.md`
-- Game-theory domain notes: `docs/domain/games-theory-domain.md`
-- ML sandbox domain notes: `docs/domain/ml-sandbox-domain.md`
-- Engineering guide: `docs/guidelines/engineering-guide.md`
-- Production package guide: `docs/guidelines/production-package-guide.md`
-- Architecture diagrams: `docs/architecture/`
-- Project lifecycle workflow: `docs/guidelines/project-lifecycle.md`
-- Release workflow: `docs/guidelines/release-workflow.md`
-
-## Repository Map
-
-| Path                 | Category           | Notes                                                                                               |
-|----------------------|--------------------|-----------------------------------------------------------------------------------------------------|
-| `games_theory/`      | Production package | CLI entry points, predictors, resource helpers, tests, release tooling.                             |
-| `docs/domain/`       | Documentation      | DDD-oriented bounded contexts, ubiquitous language, and domain rules split by domain.               |
-| `docs/guidelines/`   | Documentation      | Engineering rules, anti-patterns, repository guide, and documentation standards.                    |
-| `docs/architecture/` | Documentation      | Integration and control-flow diagrams.                                                              |
-| `docs/research/`     | Documentation      | Research notes for tool choices, release automation alternatives, and third-party workflow options. |
-| `docs/projects/`     | Documentation      | Temporary active project plans governed by the project lifecycle.                                   |
-| `scripts/`           | Tooling            | Repeatable local automation and agent verification scripts.                                         |
-| `nn/`                | Experiment         | Classical perceptron and feed-forward NN utilities used by `nn/nn_main.py`.                         |
-| `knn/`               | Experiment         | NumPy-based `KnnCore`, charting, and dataset helpers used by `knn_main.py`.                         |
-| `TF/`                | Experiment         | TensorFlow prototypes (`gpu_test.py`, `neural_network.py`).                                         |
-| `scratch/`           | Experiment         | Throwaway explorations for quick algorithm checks.                                                  |
+This guide contains the operational information needed to set up, run, test, package, and release NeuralNetworks.
 
 ## Environment And Setup
 
@@ -60,15 +33,6 @@ This guide contains operational repository information for maintainers and agent
 
 - `games-theory-init [path] [--overwrite] [--generate-internals]`: copies packaged defaults into `<path>/data/`, writes `resource_path`, and optionally regenerates derived files.
 - `games-theory <player_points> <ai_points> <cells...> [--config DIR]`: validates board length, loads config/resources, triggers the predictor loop, and writes the selected move as `{"x": <column>, "y": <row>}` to standard output (`null` when no legal move exists). Coordinates are zero-based from the top-left; diagnostics are written to standard error.
-- `games_theory/resources/resource.py`: owns `Resource.load/save`, `copy_defaults`, `generate_qtable_file`, and `generate_state_file`.
-- `games_theory/src/default_predictor.py`: orchestrates evaluation and action selection.
-- `games_theory/src/config_repository.py`: loads typed game configuration for the CLI/process boundary.
-- `games_theory/src/domain_types.py`: defines shared state, points, pending-move, configuration, and Q-table contracts.
-- `games_theory/src/predictor/state_encoder.py`: maps external `X/O/N` boards into bot-relative canonical states.
-- `games_theory/src/predictor/state_repository.py`: owns `state.json` reads/writes for pending moves.
-- `games_theory/src/predictor/qtable_repository.py`: owns `qtable.json` reads/writes and lazy neighbour registration.
-- `games_theory/src/generator.py`: enumerates bot moves for canonical board states.
-- `games_theory/src/move_coordinate_deriver.py`: provides `MoveCoordinateDeriver`, which validates a selected transition and maps its changed row-major cell to the public `MoveCoordinate` contract.
 
 ### Configuration And Data Assets
 
@@ -90,11 +54,11 @@ This guide contains operational repository information for maintainers and agent
 
 ### Testing
 
-- `games_theory/test/src/test_default_predictor.py`: verifies pending-move persistence and the Q-update rule.
-- `games_theory/test/src/test_generator.py`: verifies canonical neighbour generation for bot moves.
-- `games_theory/test/src/test_state_encoder.py`: verifies `X/O/N` to `-1/0/1` normalization relative to `ai-char`.
-- `games_theory/test/src/test_move_coordinate_deriver.py`: verifies legal transition validation and row-major state-to-coordinate conversion.
-- `games_theory/test/resources/`: verifies resource copy/save helpers.
+- Predictor tests cover pending-move persistence and the Q-update rule.
+- Generator tests cover canonical neighbour generation for bot moves.
+- State-encoding tests cover `X/O/N` normalization relative to `ai-char`.
+- Coordinate tests cover legal transition validation and row-major state-to-coordinate conversion.
+- Resource tests cover default copying, loading, and saving.
 
 ### Release Workflow
 
@@ -105,35 +69,25 @@ Pull request titles and commit subjects must follow the conventional format docu
 
 ## Experiment Sandboxes
 
-- `nn/`: `Perceptron`, `NnCore`, and associated tests; invoked by `nn/nn_main.py`.
-- `knn/`: distance calculation, neighbor voting, harmonic weighting; exercised via `knn_main.py`.
-- `TF/`: TensorFlow GPU validation and prototype network definitions.
-- `scratch/`: quick experiments such as line separation scripts and logic gate demos.
-- Install only the selected sandbox dependencies with `pip install -r <area>/requirements.txt`, where `<area>` is `nn`, `knn`, `TF`, or `scratch`.
-- Testing expectation: prioritize correctness and learning value; production packaging rigor is not required unless the change crosses production boundaries.
+The experimental areas cover perceptrons and feed-forward networks, k-NN distance and voting strategies, TensorFlow/GPU checks, and small algorithm prototypes. Each area owns an independent dependency set that can be installed with:
+
+```bash
+pip install -r <area>/requirements.txt
+```
+
+Supported values for `<area>` are `nn`, `knn`, `TF`, and `scratch`. Experimental verification prioritizes algorithmic correctness and reproducibility rather than production packaging.
 
 ## Tooling And Scripts
 
 - `games_theory/requirements.txt`: production runtime compatibility and test coverage dependencies; `pyproject.toml` remains authoritative for installed package runtime dependencies.
 - `scripts/requirements.txt`: complete production-verification environment, including `games_theory/requirements.txt` and package build tooling.
 - `nn/requirements.txt`, `knn/requirements.txt`, `TF/requirements.txt`, `scratch/requirements.txt`: sandbox-specific dependencies derived from each area's imports.
-- `chess_runtime.sh`: helper script for chess-oriented experiments; inspect parameters before running.
 - `scripts/workflow/`: release automation helpers used by GitHub Actions and their deterministic checks.
 - `scripts/workflow/build_dependency_lock.sh`: generates and verifies the release dependency lock in a clean environment, including universal-wheel availability and CLI smoke checks.
 - `scripts/workflow/generate_dependency_lock.py`: reads runtime requirements from the built wheel metadata and uses `pip-compile` to emit exact transitive pins with SHA-256 hashes.
-- `scripts/verify.sh`: repeatable agent verification: compile production code, run unit, release tooling tests and build package artifacts.
+- `scripts/verify.sh`: repeatable verification: compile production code, run unit, release tooling tests and build package artifacts.
 - `scripts/tictactoe_rebuild.sh`: reinstall package locally and optionally reset tic-tac-toe resources; pass `--reset` as the second argument for non-interactive reset.
 - `scripts/tictactoe_run.sh`: run a tic-tac-toe CLI smoke command against generated resources.
 - `dist/`: output of `flit build`; clean if artifacts become stale.
 
-Repeatable workflows, smoke tests, and agent verification belong under `scripts/**`. Keep Bash scripts deterministic and shell-safe with `set -euo pipefail`. Document user-facing scripts here or in the root `README.md`; GitHub Actions Python helpers belong under `scripts/workflow/**`.
-
-## Quality Reference
-
-- Follow `AGENTS.md` for agent routing and review policy.
-- Use `docs/domain/`, `docs/guidelines/`, and `docs/architecture/` as durable design context before changing production behaviour.
-- Plan non-trivial changes in `docs/projects/` before implementation, finish each process with a test phase, move durable outcomes/TODOs to docs, and delete completed plans.
-- Keep repeatable automation in `scripts/`.
-- Production work in `games_theory/**` demands API stability, packaging fidelity, and adequate tests.
-- Experimental directories focus on correctness and learning value.
-- Treat changes to `config.json`, `state.json`, and `qtable.json` formats as production changes even when they are made through tooling or documentation work.
+Shell automation is deterministic and fails safely with `set -euo pipefail`. Commands that overwrite local resources expose that behavior explicitly.


### PR DESCRIPTION
## Summary

- keep the root README concise and human-facing
- centralize repository mapping and task routing in AGENTS.md
- make domain, engineering, operational, lifecycle, and production documentation independent from agent-specific instructions
- correct the Q-learning architecture diagram to represent one CLI invocation
- classify root data files as user-owned runtime state and remove stale operational references

## Why

Repository routing and documentation ownership were duplicated across durable documentation. This made engineering and domain guides describe how an agent should navigate the repository instead of describing the application, domain, and operating model themselves.

## Impact

Documentation now has clearer ownership: README introduces the project, AGENTS.md routes repository work, and docs remain usable as standalone technical and domain references.

## Validation

- git diff --check
- 28 package unit tests passed
- release tooling tests passed
- documentation audit found no agent-specific references under docs

## Known verification limits

- scripts/verify.sh could not run its build step because the local build package is not installed
- the PlantUML diagram was reviewed as source but not rendered because PlantUML is unavailable locally